### PR TITLE
Feature implement get my fees estimate

### DIFF
--- a/mws/apis/products.py
+++ b/mws/apis/products.py
@@ -1,6 +1,7 @@
 """Amazon MWS Products API."""
 from typing import List
 
+import mws.models.products
 from mws import MWS, utils
 from mws.utils import enumerate_keyed_param
 
@@ -166,7 +167,8 @@ class Products(MWS):
         return self.make_request(data)
 
     def get_my_fees_estimate(
-            self, fees_estimates: List[utils.FeesEstimateRequestItem]):
+            self, fees_estimates: List[
+                mws.models.products.FeesEstimateRequestItem]):
         data = {
             'Action': 'GetMyFeesEstimate',
         }

--- a/mws/apis/products.py
+++ b/mws/apis/products.py
@@ -1,6 +1,8 @@
 """Amazon MWS Products API."""
+from typing import List
 
 from mws import MWS, utils
+from mws.utils import enumerate_keyed_param
 
 
 class Products(MWS):
@@ -163,9 +165,15 @@ class Products(MWS):
         }
         return self.make_request(data)
 
-    # # # TODO add this
-    # def get_my_fees_estimate(self):
-    #     pass
+    def get_my_fees_estimate(
+            self, fees_estimates: List[utils.FeesEstimateRequestItem]):
+        data = {
+            'Action': 'GetMyFeesEstimate',
+        }
+        attrs = [fe.serialize() for fe in fees_estimates]
+        data.update(enumerate_keyed_param(
+            'FeesEstimateRequestList.FeesEstimateRequest.', attrs))
+        return self.make_request(data, method='POST')
 
     def get_my_price_for_sku(self, marketplace_id, skus, condition=None):
         """

--- a/mws/models/products.py
+++ b/mws/models/products.py
@@ -1,0 +1,62 @@
+from typing import Optional
+
+
+class ListingPrice:
+    def __init__(self, currency_code: str, amount: float):
+        self.currency_code = currency_code
+        self.amount = amount
+
+
+class ShippingPrice:
+    def __init__(self, currency_code: str, amount: float):
+        self.currency_code = currency_code
+        self.amount = amount
+
+
+class Points:
+    def __init__(self, points_number: int):
+        self.points_number = points_number
+
+
+class PriceToEstimateFees:
+    def __init__(
+            self, listing_price: ListingPrice, shipping_price: ShippingPrice,
+            points: Optional[Points] = None):
+        self.listing_price = listing_price
+        self.shipping_price = shipping_price
+        self.points = points
+
+
+class FeesEstimateRequestItem:
+    def __init__(
+            self, marketplace_id: str, id_type: str, id_value: str,
+            is_amazon_fulfilled: bool, identifier: str,
+            price_to_estimate_fees: PriceToEstimateFees):
+        self.marketplace_id = marketplace_id
+        self.id_type = id_type
+        self.id_value = id_value
+        self.is_amazon_fulfilled = is_amazon_fulfilled
+        self.identifier = identifier
+        self.price_to_estimate_fees = price_to_estimate_fees
+
+    def serialize(self):
+        data = {
+            'MarketplaceId': self.marketplace_id,
+            'IdType': self.id_type,
+            'IdValue': self.id_value,
+            'IsAmazonFulfilled': self.is_amazon_fulfilled,
+            'Identifier': self.identifier,
+            'PriceToEstimateFees.ListingPrice.CurrencyCode':
+                self.price_to_estimate_fees.listing_price.currency_code,
+            'PriceToEstimateFees.ListingPrice.Amount':
+                self.price_to_estimate_fees.listing_price.amount,
+            'PriceToEstimateFees.Shipping.CurrencyCode':
+                self.price_to_estimate_fees.shipping_price.currency_code,
+            'PriceToEstimateFees.Shipping.Amount':
+                self.price_to_estimate_fees.shipping_price.amount,
+
+        }
+        if self.price_to_estimate_fees.points is not None:
+            data['PriceToEstimateFees.Points.PointsNumber'] = \
+                self.price_to_estimate_fees.points.points_number
+        return data

--- a/mws/utils.py
+++ b/mws/utils.py
@@ -10,68 +10,6 @@ import base64
 import datetime
 import hashlib
 import xml.etree.ElementTree as ET
-from typing import Optional
-
-
-class ListingPrice:
-    def __init__(self, currency_code: str, amount: float):
-        self.currency_code = currency_code
-        self.amount = amount
-
-
-class ShippingPrice:
-    def __init__(self, currency_code: str, amount: float):
-        self.currency_code = currency_code
-        self.amount = amount
-
-
-class Points:
-    def __init__(self, points_number: int):
-        self.points_number = points_number
-
-
-class PriceToEstimateFees:
-    def __init__(
-            self, listing_price: ListingPrice, shipping_price: ShippingPrice,
-            points: Optional[Points] = None):
-        self.listing_price = listing_price
-        self.shipping_price = shipping_price
-        self.points = points
-
-
-class FeesEstimateRequestItem:
-    def __init__(
-            self, marketplace_id: str, id_type: str, id_value: str,
-            is_amazon_fulfilled: bool, identifier: str,
-            price_to_estimate_fees: PriceToEstimateFees):
-        self.marketplace_id = marketplace_id
-        self.id_type = id_type
-        self.id_value = id_value
-        self.is_amazon_fulfilled = is_amazon_fulfilled
-        self.identifier = identifier
-        self.price_to_estimate_fees = price_to_estimate_fees
-
-    def serialize(self):
-        data = {
-            'MarketplaceId': self.marketplace_id,
-            'IdType': self.id_type,
-            'IdValue': self.id_value,
-            'IsAmazonFulfilled': self.is_amazon_fulfilled,
-            'Identifier': self.identifier,
-            'PriceToEstimateFees.ListingPrice.CurrencyCode':
-                self.price_to_estimate_fees.listing_price.currency_code,
-            'PriceToEstimateFees.ListingPrice.Amount':
-                self.price_to_estimate_fees.listing_price.amount,
-            'PriceToEstimateFees.Shipping.CurrencyCode':
-                self.price_to_estimate_fees.shipping_price.currency_code,
-            'PriceToEstimateFees.Shipping.Amount':
-                self.price_to_estimate_fees.shipping_price.amount,
-
-        }
-        if self.price_to_estimate_fees.points is not None:
-            data['PriceToEstimateFees.Points.PointsNumber'] = \
-                self.price_to_estimate_fees.points.points_number
-        return data
 
 
 class ObjectDict(dict):

--- a/mws/utils.py
+++ b/mws/utils.py
@@ -10,6 +10,64 @@ import base64
 import datetime
 import hashlib
 import xml.etree.ElementTree as ET
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class ListingPrice:
+    currency_code: str
+    amount: float
+
+
+@dataclass
+class ShippingPrice:
+    currency_code: str
+    amount: float
+
+
+@dataclass
+class Points:
+    points_number: int
+
+
+@dataclass
+class PriceToEstimateFees:
+    listing_price: ListingPrice
+    shipping_price: ShippingPrice
+    points: Optional[Points] = None
+
+
+@dataclass
+class FeesEstimateRequestItem:
+    marketplace_id: str
+    id_type: str
+    id_value: str
+    is_amazon_fulfilled: bool
+    identifier: str
+    price_to_estimate_fees: PriceToEstimateFees
+
+    def serialize(self):
+        data = {
+            'MarketplaceId': self.marketplace_id,
+            'IdType': self.id_type,
+            'IdValue': self.id_value,
+            'IsAmazonFulfilled': self.is_amazon_fulfilled,
+            'Identifier': self.identifier,
+            'PriceToEstimateFees.ListingPrice.CurrencyCode':
+                self.price_to_estimate_fees.listing_price.currency_code,
+            'PriceToEstimateFees.ListingPrice.Amount':
+                self.price_to_estimate_fees.listing_price.amount,
+            'PriceToEstimateFees.Shipping.CurrencyCode':
+                self.price_to_estimate_fees.shipping_price.currency_code,
+            'PriceToEstimateFees.Shipping.Amount':
+                self.price_to_estimate_fees.shipping_price.amount,
+
+        }
+        if self.price_to_estimate_fees.points is not None:
+            data['PriceToEstimateFees.Points.PointsNumber'] = \
+                self.price_to_estimate_fees.points.points_number
+        return data
 
 
 class ObjectDict(dict):

--- a/mws/utils.py
+++ b/mws/utils.py
@@ -10,42 +10,46 @@ import base64
 import datetime
 import hashlib
 import xml.etree.ElementTree as ET
-from dataclasses import dataclass
 from typing import Optional
 
 
-@dataclass
 class ListingPrice:
-    currency_code: str
-    amount: float
+    def __init__(self, currency_code: str, amount: float):
+        self.currency_code = currency_code
+        self.amount = amount
 
 
-@dataclass
 class ShippingPrice:
-    currency_code: str
-    amount: float
+    def __init__(self, currency_code: str, amount: float):
+        self.currency_code = currency_code
+        self.amount = amount
 
 
-@dataclass
 class Points:
-    points_number: int
+    def __init__(self, points_number: int):
+        self.points_number = points_number
 
 
-@dataclass
 class PriceToEstimateFees:
-    listing_price: ListingPrice
-    shipping_price: ShippingPrice
-    points: Optional[Points] = None
+    def __init__(
+            self, listing_price: ListingPrice, shipping_price: ShippingPrice,
+            points: Optional[Points] = None):
+        self.listing_price = listing_price
+        self.shipping_price = shipping_price
+        self.points = points
 
 
-@dataclass
 class FeesEstimateRequestItem:
-    marketplace_id: str
-    id_type: str
-    id_value: str
-    is_amazon_fulfilled: bool
-    identifier: str
-    price_to_estimate_fees: PriceToEstimateFees
+    def __init__(
+            self, marketplace_id: str, id_type: str, id_value: str,
+            is_amazon_fulfilled: bool, identifier: str,
+            price_to_estimate_fees: PriceToEstimateFees):
+        self.marketplace_id = marketplace_id
+        self.id_type = id_type
+        self.id_value = id_value
+        self.is_amazon_fulfilled = is_amazon_fulfilled
+        self.identifier = identifier
+        self.price_to_estimate_fees = price_to_estimate_fees
 
     def serialize(self):
         data = {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 requests
+dataclasses

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 requests
-dataclasses

--- a/tests/request_methods/test_products.py
+++ b/tests/request_methods/test_products.py
@@ -3,8 +3,8 @@ Tests for the Products API class.
 """
 import unittest
 import mws
-from mws.utils import ShippingPrice, ListingPrice, PriceToEstimateFees, \
-    FeesEstimateRequestItem
+from mws.models.products import ListingPrice, ShippingPrice, \
+    PriceToEstimateFees, FeesEstimateRequestItem
 from .utils import CommonRequestTestTools
 from .utils import transform_bool
 from .utils import transform_string

--- a/tests/request_methods/test_products.py
+++ b/tests/request_methods/test_products.py
@@ -3,6 +3,8 @@ Tests for the Products API class.
 """
 import unittest
 import mws
+from mws.utils import ShippingPrice, ListingPrice, PriceToEstimateFees, \
+    FeesEstimateRequestItem
 from .utils import CommonRequestTestTools
 from .utils import transform_bool
 from .utils import transform_string
@@ -291,3 +293,73 @@ class ProductsTestCase(unittest.TestCase, CommonRequestTestTools):
         self.assertEqual(params["Action"], "GetProductCategoriesForASIN")
         self.assertEqual(params["MarketplaceId"], transform_string(marketplace_id))
         self.assertEqual(params["ASIN"], asin)
+
+    def test_get_my_fees_estimate(self):
+        """
+        GetMyFeesEstimate operation.
+        """
+        marketplace_id = 'ATVPDKIKX0DER'
+        sku = 'cool-product'
+        sp = ShippingPrice(currency_code='USD', amount=0)
+
+        lp = ListingPrice(currency_code='USD', amount=15.14)
+
+        pte = PriceToEstimateFees(lp, sp)
+
+        feri = FeesEstimateRequestItem(
+            marketplace_id, 'SellerSKU', sku, is_amazon_fulfilled=True,
+            identifier=sku, price_to_estimate_fees=pte)
+
+        params = self.api.get_my_fees_estimate([feri])
+        self.assert_common_params(params)
+        self.assertEqual(params["Action"], "GetMyFeesEstimate")
+        self.assertEqual(
+            params[
+                'FeesEstimateRequestList.FeesEstimateRequest.1.MarketplaceId'],
+            marketplace_id,
+        )
+        self.assertEqual(
+            params[
+                'FeesEstimateRequestList.FeesEstimateRequest.1.IdType'],
+            'SellerSKU',
+        )
+        self.assertEqual(
+            params[
+                'FeesEstimateRequestList.FeesEstimateRequest.1.IdValue'],
+            sku,
+        )
+        self.assertEqual(
+            params[
+                'FeesEstimateRequestList.FeesEstimateRequest.1.'
+                'IsAmazonFulfilled'],
+            'true',
+        )
+        self.assertEqual(
+            params[
+                'FeesEstimateRequestList.FeesEstimateRequest.1.Identifier'],
+            sku,
+        )
+        self.assertEqual(
+            params[
+                'FeesEstimateRequestList.FeesEstimateRequest.1.'
+                'PriceToEstimateFees.ListingPrice.CurrencyCode'],
+            'USD',
+        )
+        self.assertEqual(
+            params[
+                'FeesEstimateRequestList.FeesEstimateRequest.1.'
+                'PriceToEstimateFees.ListingPrice.Amount'],
+            '15.14',
+        )
+        self.assertEqual(
+            params[
+                'FeesEstimateRequestList.FeesEstimateRequest.1.'
+                'PriceToEstimateFees.Shipping.CurrencyCode'],
+            'USD',
+        )
+        self.assertEqual(
+            params[
+                'FeesEstimateRequestList.FeesEstimateRequest.1.'
+                'PriceToEstimateFees.Shipping.Amount'],
+            '0',
+        )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,6 @@
 from mws.mws import calc_request_description
-from mws.utils import calc_md5
+from mws.utils import calc_md5, ShippingPrice, ListingPrice, \
+    PriceToEstimateFees, FeesEstimateRequestItem
 
 
 def test_calc_md5():
@@ -29,3 +30,28 @@ def test_calc_request_description(access_key, account_id):
         "&Timestamp=2017-08-12T19%3A40%3A35Z"
         "&Version=2017-01-01"
     )
+
+
+def test_fees_estimates_data_classes():
+    marketplace_id = 'ATVPDKIKX0DER'
+    sku = 'cool-product'
+    sp = ShippingPrice(currency_code='USD', amount=0)
+
+    lp = ListingPrice(currency_code='USD', amount=15.14)
+
+    pte = PriceToEstimateFees(lp, sp)
+
+    feri = FeesEstimateRequestItem(
+        marketplace_id, 'SellerSKU', sku, is_amazon_fulfilled=True,
+        identifier=sku, price_to_estimate_fees=pte)
+    assert feri.serialize() == {
+        'MarketplaceId': 'ATVPDKIKX0DER',
+        'IdType': 'SellerSKU',
+        'IdValue': 'cool-product',
+        'IsAmazonFulfilled': True,
+        'Identifier': 'cool-product',
+        'PriceToEstimateFees.ListingPrice.CurrencyCode': 'USD',
+        'PriceToEstimateFees.ListingPrice.Amount': 15.14,
+        'PriceToEstimateFees.Shipping.CurrencyCode': 'USD',
+        'PriceToEstimateFees.Shipping.Amount': 0,
+    }

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,6 @@
 from mws.mws import calc_request_description
-from mws.utils import calc_md5, ShippingPrice, ListingPrice, \
+from mws.utils import calc_md5
+from mws.models.products import ListingPrice, ShippingPrice, \
     PriceToEstimateFees, FeesEstimateRequestItem
 
 


### PR DESCRIPTION
This PR aims to implement get_my_fees_estimate

The tricky part about this method is to:

Reuse the existing utils in a DRY manner.
Enforcing the method's client to structure the input data into a certain (pretty complicated) format.
Following some best practices from Domain Driven Design, I used classes to represent the value objects (such as ListingPrice, ShippingPrice, .. etc). This allows the client to construct the complicated request in a simple manner.
I also made use of Python3 type annotations to clarify the data types.

I've also included a test case to elaborate how to use the method.

Unfortunately, I couldn't use dataclasses because the original codebase should be Python 3.5 compatible.