### PR TITLE
PAM PR-220 updates

### DIFF
--- a/mws/apis/products.py
+++ b/mws/apis/products.py
@@ -2,7 +2,7 @@
 from typing import List
 
 from mws import MWS
-from mws.models.products import FeesEstimateRequestItem
+from mws.models.products import FeesEstimateRequest
 from mws.utils import enumerate_keyed_param
 from mws.utils.params import coerce_to_bool
 from mws.utils.params import enumerate_param
@@ -156,11 +156,15 @@ class Products(MWS):
             },
         )
 
-    def get_my_fees_estimate(self, fees_estimates: List[FeesEstimateRequestItem]):
+    def get_my_fees_estimate(self, *fees_estimates: FeesEstimateRequest):
+        """Returns the estimated fees for a list of products.
 
-        attrs = [fe.serialize() for fe in fees_estimates]
+        Docs:
+        https://docs.developer.amazonservices.com/en_US/products/Products_GetMyFeesEstimate.html
+        """
+        estimates = [fe.to_dict() for fe in fees_estimates]
         data = enumerate_keyed_param(
-            "FeesEstimateRequestList.FeesEstimateRequest.", attrs
+            "FeesEstimateRequestList.FeesEstimateRequest.", estimates
         )
         return self.make_request("GetMyFeesEstimate", data, method="POST")
 

--- a/mws/apis/products.py
+++ b/mws/apis/products.py
@@ -156,13 +156,13 @@ class Products(MWS):
             },
         )
 
-    def get_my_fees_estimate(self, *fees_estimates: FeesEstimateRequest):
+    def get_my_fees_estimate(self, fees_estimate: FeesEstimateRequest, *fees_estimates: FeesEstimateRequest):
         """Returns the estimated fees for a list of products.
 
         Docs:
         https://docs.developer.amazonservices.com/en_US/products/Products_GetMyFeesEstimate.html
         """
-        estimates = [fe.to_dict() for fe in fees_estimates]
+        estimates = [fees_estimate] + [fe.to_dict() for fe in fees_estimates]
         data = enumerate_keyed_param(
             "FeesEstimateRequestList.FeesEstimateRequest.", estimates
         )

--- a/mws/models/base.py
+++ b/mws/models/base.py
@@ -1,7 +1,12 @@
 """Base models for datatypes used in MWS."""
 
+from abc import ABCMeta, abstractmethod
+
 
 class MWSDataType:
+    __metaclass__ = ABCMeta
+
+    @abstractmethod
     def to_dict(self) -> dict:
-        """Must be initialized on subclass."""
-        raise NotImplementedError
+        """Returns a flattened dict of parameters suitable for an MWS request."""
+        pass

--- a/mws/models/base.py
+++ b/mws/models/base.py
@@ -1,0 +1,7 @@
+"""Base models for datatypes used in MWS."""
+
+
+class MWSDataType:
+    def to_dict(self) -> dict:
+        """Must be initialized on subclass."""
+        raise NotImplementedError

--- a/mws/models/base.py
+++ b/mws/models/base.py
@@ -1,12 +1,10 @@
 """Base models for datatypes used in MWS."""
 
-from abc import ABCMeta, abstractmethod
+from abc import ABC, abstractmethod
 
 
-class MWSDataType:
-    """Abstract base class for data type models used for MWS requests."""
-
-    __metaclass__ = ABCMeta
+class MWSDataType(ABC):
+    """Base class for data type models used for MWS requests."""
 
     @abstractmethod
     def to_dict(self) -> dict:

--- a/mws/models/base.py
+++ b/mws/models/base.py
@@ -4,6 +4,8 @@ from abc import ABCMeta, abstractmethod
 
 
 class MWSDataType:
+    """Abstract base class for data type models used for MWS requests."""
+
     __metaclass__ = ABCMeta
 
     @abstractmethod

--- a/mws/models/products.py
+++ b/mws/models/products.py
@@ -1,66 +1,101 @@
+"""Datatype models for Products API."""
+
 from typing import Optional
 
+from mws.utils import flat_param_dict
 
-class ListingPrice:
-    def __init__(self, currency_code: str, amount: float):
-        self.currency_code = currency_code
+from .base import MWSDataType
+
+
+class MoneyType(MWSDataType):
+    def __init__(self, amount: float, currency_code: str):
         self.amount = amount
-
-
-class ShippingPrice:
-    def __init__(self, currency_code: str, amount: float):
         self.currency_code = currency_code
-        self.amount = amount
+
+    def to_dict(self) -> dict:
+        return {
+            "Amount": self.amount,
+            "CurrencyCode": self.currency_code,
+        }
 
 
-class Points:
-    def __init__(self, points_number: int):
+class Points(MWSDataType):
+    def __init__(self, points_number: int, monetary_value: MoneyType):
         self.points_number = points_number
+        assert isinstance(
+            monetary_value, MoneyType
+        ), "monetary_value must be a MoneyType model instance."
+        self.monetary_value = monetary_value
+
+    def to_dict(self) -> dict:
+        data = {"PointsNumber": self.points_number}
+        data.update(
+            flat_param_dict(self.monetary_value.to_dict(), prefix="PointsMonetaryValue")
+        )
+        return data
 
 
-class PriceToEstimateFees:
+class PriceToEstimateFees(MWSDataType):
     def __init__(
         self,
-        listing_price: ListingPrice,
-        shipping_price: ShippingPrice,
+        listing_price: MoneyType,
+        shipping: MoneyType,
         points: Optional[Points] = None,
     ):
+        assert isinstance(
+            listing_price, MoneyType
+        ), "listing_price must be a MoneyType model instance."
+        assert isinstance(
+            shipping, MoneyType
+        ), "shipping must be a MoneyType model instance."
         self.listing_price = listing_price
-        self.shipping_price = shipping_price
+        self.shipping = shipping
+        if points is not None:
+            assert isinstance(points, Points), "points must be a Points model instance."
         self.points = points
 
+    def to_dict(self) -> dict:
+        data = {}
+        data.update(
+            flat_param_dict(self.listing_price.to_dict(), prefix="ListingPrice")
+        )
+        data.update(flat_param_dict(self.shipping.to_dict(), prefix="Shipping"))
+        if self.points is not None:
+            data.update(flat_param_dict(self.points.to_dict(), prefix="Points"))
+        return data
 
-class FeesEstimateRequestItem:
+
+class FeesEstimateRequest(MWSDataType):
     def __init__(
         self,
         marketplace_id: str,
         id_type: str,
         id_value: str,
+        price_to_estimate_fees: PriceToEstimateFees,
         is_amazon_fulfilled: bool,
         identifier: str,
-        price_to_estimate_fees: PriceToEstimateFees,
     ):
         self.marketplace_id = marketplace_id
         self.id_type = id_type
         self.id_value = id_value
-        self.is_amazon_fulfilled = is_amazon_fulfilled
         self.identifier = identifier
+        self.is_amazon_fulfilled = is_amazon_fulfilled
+        assert isinstance(
+            price_to_estimate_fees, PriceToEstimateFees
+        ), "price_to_estimate_fees must be a PriceToEstimateFees model instance"
         self.price_to_estimate_fees = price_to_estimate_fees
 
-    def serialize(self):
+    def to_dict(self) -> dict:
         data = {
             "MarketplaceId": self.marketplace_id,
             "IdType": self.id_type,
             "IdValue": self.id_value,
-            "IsAmazonFulfilled": self.is_amazon_fulfilled,
             "Identifier": self.identifier,
-            "PriceToEstimateFees.ListingPrice.CurrencyCode": self.price_to_estimate_fees.listing_price.currency_code,
-            "PriceToEstimateFees.ListingPrice.Amount": self.price_to_estimate_fees.listing_price.amount,
-            "PriceToEstimateFees.Shipping.CurrencyCode": self.price_to_estimate_fees.shipping_price.currency_code,
-            "PriceToEstimateFees.Shipping.Amount": self.price_to_estimate_fees.shipping_price.amount,
+            "IsAmazonFulfilled": self.is_amazon_fulfilled,
         }
-        if self.price_to_estimate_fees.points is not None:
-            data[
-                "PriceToEstimateFees.Points.PointsNumber"
-            ] = self.price_to_estimate_fees.points.points_number
+        data.update(
+            flat_param_dict(
+                self.price_to_estimate_fees.to_dict(), prefix="PriceToEstimateFees"
+            )
+        )
         return data

--- a/mws/utils/params.py
+++ b/mws/utils/params.py
@@ -46,7 +46,7 @@ def enumerate_params(params=None):
 
 
 def enumerate_keyed_param(param, values):
-    """Given a param string and a dict of values, returns a flat dict of keyed, enumerated params.
+    """Given a param string and a list of values dicts, returns a flat dict of keyed, enumerated params.
     Each dict in the values list must pertain to a single item and its data points.
 
     Example:

--- a/tests/utils_lib/test_small_fry.py
+++ b/tests/utils_lib/test_small_fry.py
@@ -3,10 +3,9 @@
 from mws.mws import calc_request_description
 from mws.utils import calc_md5
 from mws.models.products import (
-    ListingPrice,
-    ShippingPrice,
+    MoneyType,
     PriceToEstimateFees,
-    FeesEstimateRequestItem,
+    FeesEstimateRequest,
 )
 
 
@@ -42,21 +41,20 @@ def test_calc_request_description(cred_access_key, cred_account_id):
 def test_fees_estimates_data_classes():
     marketplace_id = "ATVPDKIKX0DER"
     sku = "cool-product"
-    sp = ShippingPrice(currency_code="USD", amount=0)
+    fees = PriceToEstimateFees(
+        listing_price=MoneyType(amount=15.14, currency_code="USD"),
+        shipping=MoneyType(amount=0, currency_code="USD"),
+    )
 
-    lp = ListingPrice(currency_code="USD", amount=15.14)
-
-    pte = PriceToEstimateFees(lp, sp)
-
-    feri = FeesEstimateRequestItem(
+    estimate_req = FeesEstimateRequest(
         marketplace_id,
         "SellerSKU",
         sku,
         is_amazon_fulfilled=True,
         identifier=sku,
-        price_to_estimate_fees=pte,
+        price_to_estimate_fees=fees,
     )
-    assert feri.serialize() == {
+    assert estimate_req.to_dict() == {
         "MarketplaceId": "ATVPDKIKX0DER",
         "IdType": "SellerSKU",
         "IdValue": "cool-product",


### PR DESCRIPTION
Wanted to offer these changes to your [PR220 on Python Amazon MWS](https://github.com/python-amazon-mws/python-amazon-mws/pull/220), rather than try to spell these out in review comments.

**Changes:**

- Datatypes have been renamed to match those in [MWS docs](https://docs.developer.amazonservices.com/en_US/products/Products_Datatypes.html).
- A base type, `MWSDataType`, is used as the parent class for all datatypes in the project, with a method that all subclasses should implement, `to_dict`.
- The duplicate types `ListingPrice` and `ShippingPrice` have been changed to the base type, [`MoneyType`](https://docs.developer.amazonservices.com/en_US/products/Products_Datatypes.html#MoneyType), which can convert itself to a dict with its own `to_dict` method.
- Other datatypes that rely on sub-types - like `Points` which includes a `PointsMonetaryValue` of type `MoneyType` - will rely on those being the correct sub-type and attempt to flatten them using `mws.utils.flat_param_dict`.
- Tests adjusted to match these changes, with an additional change that reduces the multiple `self.assertEqual` checks into an `expected` dict and a key-by-key `assert` test.
- Finally, the signature for the request method, `get_my_fees_estimate`, has been changed to use the `*args` style, rather than a list (you can adjust downstream code simply by adding `*` in front of any list assignment you currently have).

These changes set us up to utilize the same design in other request methods in future.

If you accept this PR on your own fork here, ours will update to reflect it, and then we can accept that and merge it back. This keeps your contribution intact.